### PR TITLE
Fixed misprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,5 +350,5 @@ MigrationBackup/
 .ionide/
 Package/
 SAT/
-scwpd/
+scwdp/
 Module/

--- a/Create-SitecoreModule-DockerAssetImage.ps1
+++ b/Create-SitecoreModule-DockerAssetImage.ps1
@@ -88,7 +88,7 @@ else {
     Write-Host "`n"
 
     $packagePath = $PSScriptRoot + "\Package\$ModulePackageName"
-    $scwdpDirectory = $PSScriptRoot + "\scwpd"
+    $scwdpDirectory = $PSScriptRoot + "\scwdp"
 
     Import-Module .\SAT\tools\Sitecore.Cloud.Cmdlets.psm1
     Import-Module .\SAT\tools\Sitecore.Cloud.Cmdlets.dll


### PR DESCRIPTION
SCWDP stays for Sitecore web deploy package. 
I think it is a misprint in the folder name.