### PR TITLE
Modified directory structure to support conversion of multiple packages

### DIFF
--- a/Create-SitecoreModule-DockerAssetImage.ps1
+++ b/Create-SitecoreModule-DockerAssetImage.ps1
@@ -87,8 +87,14 @@ else {
     Write-Host "START - [Convert Sitecore Module to .scwdp]"
     Write-Host "`n"
 
+    $dateTime = (Get-Date).tostring("ddMMyyyyhhmmss")
     $packagePath = $PSScriptRoot + "\Package\$ModulePackageName"
+    $modulePackageItem = Get-Item $packagePath
+    $modulePackageNameSinExtension = $modulePackageItem.BaseName    
     $scwdpDirectory = $PSScriptRoot + "\scwdp"
+    $scwdpModuleFolder = $modulePackageNameSinExtension + "_$dateTime"
+    $scwdpDestination = "$scwdpDirectory\$scwdpModuleFolder"
+    
 
     Import-Module .\SAT\tools\Sitecore.Cloud.Cmdlets.psm1
     Import-Module .\SAT\tools\Sitecore.Cloud.Cmdlets.dll
@@ -100,13 +106,19 @@ else {
         If (!(Test-Path($scwdpDirectory))) {
             New-Item -ItemType Directory -Force -Path $scwdpDirectory
         }
+       
+        # no need to delete existing scwdp
+        #Get-ChildItem -Path $scwdpDirectory -Recurse | Foreach-object { Remove-item -Recurse -path $_.FullName }
 
-        Get-ChildItem -Path $scwdpDirectory -Recurse | Foreach-object { Remove-item -Recurse -path $_.FullName }
-
-        $scwdpPath = ConvertTo-SCModuleWebDeployPackage -Path $packagePath -Destination $scwdpDirectory -Force
+        #original
+        #$scwdpPath = ConvertTo-SCModuleWebDeployPackage -Path $packagePath -Destination $scwdpDirectory -Force
+        
+        #new
+        $scwdpPath = ConvertTo-SCModuleWebDeployPackage -Path $packagePath -Destination $scwdpDestination -Force
         Write-Host "SUCCESS - Your Sitecore Module was converted to a Sitecore WebDeploy package and is located at:" -ForegroundColor Green
         Write-Host "`n"
-        Write-Host "$scwdpPath" -ForegroundColor Yellow
+        #Write-Host "$scwdpPath" -ForegroundColor Yellow
+        Write-Host "$scwdpDestination" -ForegroundColor Yellow
         Write-Host "`n"
 
         Write-Host "=================================================================================================================================="
@@ -114,11 +126,13 @@ else {
         Write-Host "START - [Extracting Sitecore WebDeploy package]"
         Write-Host "`n"
 
-        $extractSCwdpDirectory = $scwdpDirectory + "\extract"
+        $extractSCwdpDirectory = $scwdpDestination + "\extract_scwdp"
 
         if (!(Test-Path($extractSCwdpDirectory))) {
             New-Item -ItemType Directory -Force -Path $extractSCwdpDirectory
         }
+        
+        $extractSCwdpDirectory
 
         Expand-Archive -Path "$scwdpPath" -DestinationPath "$extractSCwdpDirectory" -Force
 
@@ -127,7 +141,9 @@ else {
         Write-Host "START - [Creating Sitecore module asset image structure]"
         Write-Host "`n"
 
-        $moduleDirectory = $PSScriptRoot + "\Module"
+        #$moduleDirectory = $PSScriptRoot + "\$scwdpModuleFolder\Module"
+        $moduleDirectory = "$scwdpDestination\Module"
+        
         $cmContentDirectory = $moduleDirectory + "\cm\content"
         $dbDirectory = $moduleDirectory + "\db"
         $solrDirectory = $moduleDirectory + "\solr"
@@ -137,7 +153,7 @@ else {
             New-Item -ItemType Directory -Force -Path $moduleDirectory
         }
 
-        Remove-Item -Path $moduleDirectory -Recurse
+        #Remove-Item -Path $moduleDirectory -Recurse
 
         If (!(Test-Path($cmContentDirectory))) {
             New-Item -ItemType Directory -Force -Path $cmContentDirectory

--- a/Create-SitecoreModule-DockerAssetImage.ps1
+++ b/Create-SitecoreModule-DockerAssetImage.ps1
@@ -107,17 +107,9 @@ else {
             New-Item -ItemType Directory -Force -Path $scwdpDirectory
         }
        
-        # no need to delete existing scwdp
-        #Get-ChildItem -Path $scwdpDirectory -Recurse | Foreach-object { Remove-item -Recurse -path $_.FullName }
-
-        #original
-        #$scwdpPath = ConvertTo-SCModuleWebDeployPackage -Path $packagePath -Destination $scwdpDirectory -Force
-        
-        #new
         $scwdpPath = ConvertTo-SCModuleWebDeployPackage -Path $packagePath -Destination $scwdpDestination -Force
         Write-Host "SUCCESS - Your Sitecore Module was converted to a Sitecore WebDeploy package and is located at:" -ForegroundColor Green
-        Write-Host "`n"
-        #Write-Host "$scwdpPath" -ForegroundColor Yellow
+        Write-Host "`n"        
         Write-Host "$scwdpDestination" -ForegroundColor Yellow
         Write-Host "`n"
 
@@ -140,8 +132,7 @@ else {
         Write-Host "`n"
         Write-Host "START - [Creating Sitecore module asset image structure]"
         Write-Host "`n"
-
-        #$moduleDirectory = $PSScriptRoot + "\$scwdpModuleFolder\Module"
+        
         $moduleDirectory = "$scwdpDestination\Module"
         
         $cmContentDirectory = $moduleDirectory + "\cm\content"
@@ -152,8 +143,6 @@ else {
         If (!(Test-Path($moduleDirectory))) {
             New-Item -ItemType Directory -Force -Path $moduleDirectory
         }
-
-        #Remove-Item -Path $moduleDirectory -Recurse
 
         If (!(Test-Path($cmContentDirectory))) {
             New-Item -ItemType Directory -Force -Path $cmContentDirectory

--- a/Create-SitecoreModule-DockerAssetImage.ps1
+++ b/Create-SitecoreModule-DockerAssetImage.ps1
@@ -87,7 +87,7 @@ else {
     Write-Host "START - [Convert Sitecore Module to .scwdp]"
     Write-Host "`n"
 
-    $dateTime = (Get-Date).tostring("ddMMyyyyhhmmss")
+    $dateTime = (Get-Date).tostring("ddMMyyyyHHmmss")
     $packagePath = $PSScriptRoot + "\Package\$ModulePackageName"
     $modulePackageItem = Get-Item $packagePath
     $modulePackageNameSinExtension = $modulePackageItem.BaseName    

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # sitecore-module-docker-asset-image-creator
 This repository contains a script to handle the auto creation of a Docker Asset Image for a given Sitecore module
 
+- Clone the repo to your working machine
+- Add the Sitecore module package to Package folder under root
+- Then invoke the script as shown in example below to convert it into scwdp (used for Azure PaaS) as well as extract the scwdp into a Module folder used for generating the docker image
+   ```powershell
+    .\Create-SitecoreModule-DockerAssetImage.ps1 -ModulePackageName "Brightcove.Media.Framework-10.0.zip"
+   ```
+- The folder name is generated based on the ModulePackageName provided while invoking the script and appends the current datetime stamp in `ModulePackageName_ddMMyyyyHHmmss` format
+- Run the docker file under Module folder to generate the image. The script only extracts it for CM role. For other roles, you have to manually create role specific docker files
+- Once the image is generated, push it to your container registry to share it with other devs in your team or devops for AKS deployment
+
+![image](https://user-images.githubusercontent.com/3968213/129932632-67ee772f-63da-421e-a476-dfe08635ca69.png)
+
 # Contributors
 Robbert Hock - Twitter: @kayeeNL, GitHub: https://github.com/KayeeNL


### PR DESCRIPTION
Hi Robbert,

I have updated the script to change the directory structure for storing the scwdp, its extract and docker module all under 1 folder. This folder is named based on the Module package name provided while invoking the script. Have appended the timestamp to the folder so the script can be run multiple times without affecting the previous attempt output.

This way I was able to just add the package to the folder, run the script without worrying of losing the previous run output cleanup.

```powershell
.\Create-SitecoreModule-DockerAssetImage.ps1 -ModulePackageName “Brightcove.Media.Framework-10.0.zip”
```

![image](https://user-images.githubusercontent.com/3968213/129927732-feaf0d4b-b102-45a8-aed0-50f6edaaa6e1.png)
