### PR TITLE
Sets ErrorActionPreference to Stop

### DIFF
--- a/Create-SitecoreModule-DockerAssetImage.ps1
+++ b/Create-SitecoreModule-DockerAssetImage.ps1
@@ -30,6 +30,8 @@ param(
     [switch] $GenerateCdContentDirectory
 )
 
+$ErrorActionPreference = "Stop"
+
 #---------------------------------[Read configuration]------------------------------------------------
 $configurationPath = "configuration.json"
 $jsonConfiguration = Get-Content -Path $configurationPath | ConvertFrom-Json


### PR DESCRIPTION
There are a few areas of the script which assume the previous lines have worked, without asserting that that's true.

ErrorActionPreference ensures that the script stops as soon as there is an error, which makes it easier to debug what's happening as the errors become steadily more misleading the further down the script it gets.